### PR TITLE
Fix initial status

### DIFF
--- a/ansible/roles/generator/defaults/main.yml
+++ b/ansible/roles/generator/defaults/main.yml
@@ -31,7 +31,7 @@ generator_src: https://github.com/ess-dmsc/sinq-amorsim
 generator_home: "{{amor_dir}}/simfiles"
 generator_branch: master
 
-generator_inc: '"{{nexus}}/include;{{flatbuffers}}/include;{{rapidjson}}/include;{{rdkafka}}/include;{{streaming_data_types}}:{{googletest}}"'
+generator_inc: '"{{nexus}}/include;{{flatbuffers}}/include;{{rapidjson}}/include;{{rdkafka}}/include;{{streaming_data_types}};{{googletest}}"'
 generator_lib: '"{{nexus}}/lib;{{flatbuffers}}/lib;{{rapidjson}}/lib;{{rdkafka}}/lib"'
 generator_exe: "{{flatbuffers}}/bin"
 

--- a/ansible/roles/generator/files/config.json
+++ b/ansible/roles/generator/files/config.json
@@ -4,5 +4,12 @@
     "multiplier" : 1,
     "rate" : 10,
     "source_name": "AMOR.event.stream",
-    "timestamp_generator" : "const_timestamp"
+    "timestamp_generator" : "const_timestamp",
+    "report_time" : 1,
+    "kafka_options" : {
+	"api.version.request": "true",
+	"message.max.bytes": "131001000",
+	"fetch.message.max.bytes": "23100100",
+	"receive.message.max.bytes": "23100100"
+    }
 }

--- a/neventGenerator/control.hpp
+++ b/neventGenerator/control.hpp
@@ -6,7 +6,21 @@
 
 namespace SINQAmorSim {
 
-  enum class RunStatus { run, pause, stop, exit };
+enum class RunStatus { run, pause, stop, exit };
+static std::string Status2Str(const int value) {
+  switch (value) {
+  case int(RunStatus::run):
+    return "run";
+  case int(RunStatus::pause):
+    return "pause";
+  case int(RunStatus::stop):
+    return "stop";
+  case int(RunStatus::exit):
+    return "exit";
+  default:
+    return "unknown status";
+  }
+}
 
 struct NoControl {
   NoControl() {}
@@ -27,7 +41,7 @@ struct NoControl {
 
 struct CommandlineControl {
   CommandlineControl(Configuration &configuration) : config{configuration} {
-    status.store(int(RunStatus::run));
+    status.store(int(RunStatus::stop));
   }
   CommandlineControl(const CommandlineControl &other) = default;
 
@@ -39,9 +53,9 @@ struct CommandlineControl {
 
   int update() { return update_impl(); }
 
-  int start(int value) {
-    if (value >= 0 && value < 3) {
-      status.store(value);
+  int start(RunStatus value = RunStatus::run) {
+    if (int(value) >= 0 && int(value) < 3) {
+      status.store(int(value));
     }
     return run();
   }
@@ -56,10 +70,10 @@ private:
   SINQAmorSim::Configuration &config;
 
   int &&update_impl() {
-    std::cout << "run_status : " << status << "\t"
-              << "transmission_rate : " << std::to_string(config.rate) << "\n";
+    std::cout << "status : " << Status2Str(status) << "\t"
+              << "tr : " << std::to_string(config.rate) << "\n";
     std::string value;
-    while (status != int(RunStatus::stop)) {
+    while (status != int(RunStatus::exit)) {
       std::cin >> value;
       if (std::string(value) == "run" || std::string(value) == "ru") {
         status.store(int(RunStatus::run));
@@ -78,11 +92,11 @@ private:
         std::cin >> value;
         config.rate = std::stoi(value);
       }
+      std::cout << "status : " << Status2Str(status) << "\t"
+                << "tr : " << std::to_string(config.rate) << "\n";
     }
-    std::cout << "status : " << status << "\t"
-              << "tr : " << std::to_string(config.rate) << "\n";
     return std::move(status.load());
   }
 };
 
-} // namespace control
+} // namespace SINQAmorSim

--- a/neventGenerator/generator.hpp
+++ b/neventGenerator/generator.hpp
@@ -64,7 +64,6 @@ public:
 private:
   std::unique_ptr<Streamer> streamer{nullptr};
   std::unique_ptr<Control> control{nullptr};
-  bool initial_status;
   SINQAmorSim::Configuration config;
 
   template <class T> void run_impl(std::vector<T> &stream) {
@@ -72,7 +71,6 @@ private:
     int nev = stream.size();
     uint64_t pulseID = 0;
     int count = 0;
-    control->start(initial_status);
 
     using std::chrono::system_clock;
     auto start = system_clock::now();


### PR DESCRIPTION
- [x] generator starts in non ``transmit status``
- [x] using the ``el737 counterbox`` the process is terminated when the remote connection drop
@nikhilbiyani can you gvie it a try before I merge? To use this branch add 

``--extra-vars "generator_branch=fix-initial-status"`` 

as the ``ansible-playbook`` command line options