### PR TITLE
Update conan packages

### DIFF
--- a/neventGenerator/CMakeLists.txt
+++ b/neventGenerator/CMakeLists.txt
@@ -30,7 +30,7 @@ find_package(Rapidjson REQUIRED)
 find_package(RdKafka REQUIRED)
 find_package(Flatbuffers REQUIRED)
 find_package(HDF5 REQUIRED)
-find_package(StreamingDataTypes COMPONENTS d2247ffd906ebeeb68c9b8a2ea9f1d36c1d88a46)
+find_package(StreamingDataTypes COMPONENTS d2247ffd906ebeeb68c9b8a2ea9f1d36c1d88a46 REQUIRED)
 find_package(Googletest)
 
 option(HAVE_ZMQ "Enable 0MQ" FALSE)

--- a/neventGenerator/CMakeLists.txt
+++ b/neventGenerator/CMakeLists.txt
@@ -19,7 +19,9 @@ if(EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
   conan_basic_setup(NO_OUTPUT_DIRS)
 endif()
 
-set (CMAKE_CXX_FLAGS "-std=c++11 -pthread -D_GLIBCXX_USE_NANOSLEEP ${CMAKE_CXX_FLAGS}")
+set (CMAKE_CXX_FLAGS "-std=c++11 -D_GLIBCXX_USE_NANOSLEEP ${CMAKE_CXX_FLAGS}")
+set (CMAKE_CXX_FLAGS_DEBUG "-Wall -O0 -ggdb ${CMAKE_CXX_FLAGS}")
+set (CMAKE_CXX_FLAGS_RELEASE "-O3 -g0 ${CMAKE_CXX_FLAGS}")
 
 add_custom_target(
   extern_lib

--- a/neventGenerator/cmake/FindStreamingDataTypes.cmake
+++ b/neventGenerator/cmake/FindStreamingDataTypes.cmake
@@ -1,4 +1,5 @@
-# Locates the streaming-data-types repository and sets up a target
+# If generated flatbuffer headers are available from conan they are used,
+# otherwise locates the streaming-data-types repository and sets up a target
 # called 'flatbuffers_generate' which generates the flatbuffer headers.
 # Make your target depend on 'flatbuffers_generate'.
 # When you call this using find_package, you can specify a minimum version
@@ -9,41 +10,51 @@
 # Usage of this package requires of course the git suite to be available.
 # Contact: Dominik Werder
 
-find_path(path_include_streaming_data_types NAMES schemas/amo0_psi_sinq.fbs HINTS
-# The common case as fallback:
-${CMAKE_CURRENT_SOURCE_DIR}/../../streaming-data-types
-)
-if (NOT path_include_streaming_data_types)
-	message(FATAL_ERROR "Can not find_path() the streaming-data-types repository")
-endif()
-message(STATUS "path_include_streaming_data_types ${path_include_streaming_data_types}")
-
-if (NOT StreamingDataTypes_FIND_COMPONENTS STREQUAL "")
-add_custom_target(check_streaming_data_types ALL
-COMMAND bash -c '\(cd ${path_include_streaming_data_types} && git merge-base --is-ancestor ${StreamingDataTypes_FIND_COMPONENTS} HEAD \) || \( echo && echo ERROR\ Your\ streaming-data-types\ repository\ is\ too\ old\ we\ require\ at\ least\ ${StreamingDataTypes_FIND_COMPONENTS} && echo && exit 1 \) '
-)
-endif()
-
-set(flatbuffers_generated_headers "")
-
 set(schemas_subdir "schemas")
 set(head_out_dir "${CMAKE_CURRENT_BINARY_DIR}/${schemas_subdir}")
 file(MAKE_DIRECTORY ${head_out_dir})
-file(GLOB_RECURSE flatbuffers_schemata2 RELATIVE "${path_include_streaming_data_types}/schemas" "${path_include_streaming_data_types}/schemas/*.fbs")
 
-foreach (f0 ${flatbuffers_schemata2})
-	string(REGEX REPLACE "\\.fbs$" "" s0 ${f0})
-	set(fbs "${s0}.fbs")
-	set(fbh "${s0}_generated.h")
-	add_custom_command(
-		OUTPUT "${head_out_dir}/${fbh}"
-		COMMAND ${FLATBUFFERS_FLATC_EXECUTABLE} --cpp --gen-mutable --gen-name-strings --scoped-enums "${path_include_streaming_data_types}/schemas/${fbs}"
-		DEPENDS "${path_include_streaming_data_types}/schemas/${fbs}"
-		WORKING_DIRECTORY "${head_out_dir}"
-		COMMENT "Process ${fbs} using ${flatc}"
+if (CONAN_INCLUDE_DIRS_STREAMING-DATA-TYPES)
+	file(GLOB_RECURSE flatbuffers_generated_headers "${CONAN_INCLUDE_DIRS_STREAMING-DATA-TYPES}/*_generated.h")
+	foreach (header_file ${flatbuffers_generated_headers})
+		configure_file(${header_file} ${head_out_dir} COPYONLY)
+	endforeach()
+else ()
+	find_path(path_include_streaming_data_types NAMES schemas/f141_epics_nt.fbs HINTS
+	# The common case as fallback:
+	${CMAKE_CURRENT_SOURCE_DIR}/../../streaming-data-types
 	)
-	list(APPEND flatbuffers_generated_headers "${head_out_dir}/${fbh}")
-endforeach()
+	if (NOT path_include_streaming_data_types)
+		message(FATAL_ERROR "Can not find_path() the streaming-data-types repository")
+	endif()
+	message(STATUS "path_include_streaming_data_types ${path_include_streaming_data_types}")
+
+	if (NOT StreamingDataTypes_FIND_COMPONENTS STREQUAL "")
+		if (UNIX)
+	add_custom_target(check_streaming_data_types ALL
+	COMMAND bash -c '\(cd ${path_include_streaming_data_types} && git merge-base --is-ancestor ${StreamingDataTypes_FIND_COMPONENTS} HEAD \) || \( echo && echo ERROR\ Your\ streaming-data-types\ repository\ is\ too\ old\ we\ require\ at\ least\ ${StreamingDataTypes_FIND_COMPONENTS} && echo && exit 1 \) '
+	)
+		endif(UNIX)
+	endif()
+
+	set(flatbuffers_generated_headers "")
+
+	file(GLOB_RECURSE flatbuffers_schemata2 RELATIVE "${path_include_streaming_data_types}/schemas" "${path_include_streaming_data_types}/schemas/*.fbs")
+
+	foreach (f0 ${flatbuffers_schemata2})
+		string(REGEX REPLACE "\\.fbs$" "" s0 ${f0})
+		set(fbs "${s0}.fbs")
+		set(fbh "${s0}_generated.h")
+		add_custom_command(
+			OUTPUT "${head_out_dir}/${fbh}"
+			COMMAND ${FLATBUFFERS_FLATC_EXECUTABLE} --cpp --gen-mutable --gen-name-strings --scoped-enums "${path_include_streaming_data_types}/schemas/${fbs}"
+			DEPENDS "${path_include_streaming_data_types}/schemas/${fbs}"
+			WORKING_DIRECTORY "${head_out_dir}"
+			COMMENT "Process ${fbs} using ${FLATBUFFERS_FLATC_EXECUTABLE}"
+		)
+		list(APPEND flatbuffers_generated_headers "${head_out_dir}/${fbh}")
+	endforeach()
+endif()
 
 add_custom_target(flatbuffers_generate ALL DEPENDS ${flatbuffers_generated_headers})
 if (DEFINED check_streaming_data_types)

--- a/neventGenerator/conan/conanfile.txt
+++ b/neventGenerator/conan/conanfile.txt
@@ -1,9 +1,10 @@
 [requires]
 gtest/3121b20-dm1@ess-dmsc/testing
-FlatBuffers/1.5.0-dm1@ess-dmsc/stable
+FlatBuffers/1.9.0@ess-dmsc/stable
 hdf5/1.10.1-dm3@ess-dmsc/stable
 librdkafka/0.11.1-dm1@ess-dmsc/stable
 RapidJSON/1.1.0-dm1@ess-dmsc/stable
+streaming-data-types/361bf7b@ess-dmsc/stable
 
 [generators]
 cmake


### PR DESCRIPTION
This PR solves a conflict between sinq-amorsim and kafka-to-nexus dependencies. Since the two uses different versions of flatbuffers conflicts can arise.

Changes:
 - use the latest flatbuffer that we have available (1.9.0)
 - install streaming-data-types with conan
 - add Release and Debug mode